### PR TITLE
fix: catch exception when already associated

### DIFF
--- a/example_instancestack.yaml
+++ b/example_instancestack.yaml
@@ -146,6 +146,7 @@ Resources:
         ZipFile: |
           from __future__ import print_function
           import boto3
+          import botocore
           import json
           import os
           import time
@@ -188,9 +189,14 @@ Resources:
                           # logger.info('instance_state: {}'.format(instance_state))
           
                       # attach instance profile
-                      response = ec2.associate_iam_instance_profile(IamInstanceProfile=iam_instance_profile, InstanceId=instance['InstanceId'])
-                      # logger.info('response - associate_iam_instance_profile: {}'.format(response))
-                      r_ec2 = boto3.resource('ec2')
+                      try:
+                        response = ec2.associate_iam_instance_profile(IamInstanceProfile=iam_instance_profile, InstanceId=instance['InstanceId'])
+                        # logger.info('response - associate_iam_instance_profile: {}'.format(response))
+                      except botocore.exceptions.ClientError as error:
+                        if error.response['Error']['Code'] == 'IncorrectState' and f"There is an existing association for instance {instance['InstanceId']}" == error.response['Error']['Message']:
+                          # logger.warn("Already Associated")
+                        else:
+                          raise error
   
                       responseData = {'Success': 'Started bootstrapping for instance: '+instance['InstanceId']}
                       cfnresponse.send(event, context, status, responseData, 'CustomResourcePhysicalID')


### PR DESCRIPTION
When the association already exists the bootstrap fails, but should succeed.